### PR TITLE
update brew install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Modern, flexible and fast DynamoDB editor. Accelerate your workflow with multipl
 
 - [Download](https://dynobase.dev)
 
-or `brew cask install dynobase` on Mac.
+or `brew install --cask dynobase` on Mac.
 
 - [Releases & Changelog](https://github.com/RafalWilinski/dynobase/releases)
 


### PR DESCRIPTION
brew recently disabled `brew cask install` and switch to `brew install --cask`. 

This PR updates the readme to use the new command.

You can see others talking about the change here: https://github.com/ansible-collections/community.general/issues/1524